### PR TITLE
Ignore other attributes

### DIFF
--- a/structopt-toml-derive/Cargo.toml
+++ b/structopt-toml-derive/Cargo.toml
@@ -16,6 +16,6 @@ disable-tag = true
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0.8"
-syn   = "1.0.16"
+proc-macro2 = "1.0.10"
+syn   = "1.0.18"
 quote = "1.0.3"

--- a/structopt-toml/tests/test.rs
+++ b/structopt-toml/tests/test.rs
@@ -80,6 +80,28 @@ fn test() {
     assert_eq!(test.d3, vec![233]);
 }
 
+
+static POSSIBLE_VALUES: &[&str] = &["one", "two"];
+
+#[derive(Debug, Deserialize, StructOpt, StructOptToml)]
+#[serde(default)]
+struct Bar {
+    #[structopt(possible_values = POSSIBLE_VALUES, name = "bar")]
+    val: Option<String>,
+}
+
+#[test]
+fn test_args_with_other_attributes() {
+    let toml_str = r#"
+    bar = "one"
+    "#;
+    let test = Bar::from_args_with_toml(toml_str);
+    match dbg!(test) {
+        Err(_) => assert!(false),
+        _ => assert!(true),
+    }
+}
+
 #[test]
 fn test_toml_failed() {
     let toml_str = r#"


### PR DESCRIPTION
Hi

A code similar to the following

```rust
static POSSIBLE_VALUES: &[&str] = &["one", "two"];

#[derive(Debug, Deserialize, StructOpt, StructOptToml)]
#[serde(default)]
struct Bar {
    #[structopt(possible_values = POSSIBLE_VALUES, name = "bar")]
    val: Option<String>,
}

#[test]
fn test_args_with_other_attributes() {
    let toml_str = r#"
    bar = "one"
    "#;
    let test = Bar::from_args_with_toml(toml_str);
    match dbg!(test) {
        Err(_) => assert!(false),
        _ => assert!(true),
    }
}
```
will fail today. Because [parse_meta](https://docs.rs/syn/1.0.18/syn/struct.Attribute.html#method.parse_meta) will not be able to parse the attribute, causing the macro to panic.

I've attempted to fix this by writing an explicit parsing routine that only looks for `name = "value"` pattern and nothing more.

Is it something you want to merge? Any changes?