### PR TITLE
Change default impl

### DIFF
--- a/structopt-toml-derive/src/lib.rs
+++ b/structopt-toml-derive/src/lib.rs
@@ -54,8 +54,7 @@ fn impl_structopt_for_struct(
 
         impl Default for #name {
             fn default() -> Self {
-                let args = vec!["bin"];
-                #name::from_iter(args.iter())
+                #name::from_args()
             }
         }
     }


### PR DESCRIPTION
Delegate to clap parsing with the process commandline arguments,
so it won't fail on missing required parameters.

A simple way (I think) to solve this: https://github.com/dalance/structopt-toml/issues/8